### PR TITLE
Added service_node and deregister_vote objects to help with compilation

### DIFF
--- a/src/MicroCore.cpp
+++ b/src/MicroCore.cpp
@@ -22,7 +22,8 @@ namespace xmreg
  */
 MicroCore::MicroCore():      
         m_mempool(core_storage),
-        core_storage(m_mempool),
+        core_storage(m_mempool, m_service_node_list, m_deregister_vote_pool),
+        m_service_node_list(core_storage),
         m_device {&hw::get_device("default")}
 {
 

--- a/src/MicroCore.h
+++ b/src/MicroCore.h
@@ -31,6 +31,8 @@ class MicroCore {
 
     tx_memory_pool m_mempool;
     Blockchain core_storage;
+    service_nodes::service_node_list m_service_node_list;
+    loki::deregister_vote_pool m_deregister_vote_pool;
 
     hw::device* m_device;
 

--- a/src/monero_headers.h
+++ b/src/monero_headers.h
@@ -23,6 +23,8 @@
 
 #include "cryptonote_core/tx_pool.h"
 #include "cryptonote_core/blockchain.h"
+#include "cryptonote_core/service_node_list.h"
+#include "cryptonote_core/service_node_deregister.h"
 #include "blockchain_db/lmdb/db_lmdb.h"
 
 #include "wallet/wallet2.h"


### PR DESCRIPTION
Adding these arguments in the constructor of MicroCore() follows the number of arguments in cryptonote::Blockchain::Blockchain(tx_memory_pool&, service_node_list&, deregister_vote_pool&)