### PR TITLE
Correct output tx pub keys and per-output unlock support

### DIFF
--- a/sql/openloki.sql
+++ b/sql/openloki.sql
@@ -89,6 +89,7 @@ CREATE TABLE IF NOT EXISTS `Outputs` (
   `out_index` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   `mixin` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `unlock_time` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `out_pub_key` (`out_pub_key`),
   KEY `tx_id` (`tx_id`),

--- a/sql/openloki_test.sql
+++ b/sql/openloki_test.sql
@@ -188,6 +188,7 @@ CREATE TABLE IF NOT EXISTS `Outputs` (
   `out_index` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   `mixin` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   `timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `unlock_time` bigint(20) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `out_pub_key` (`out_pub_key`),
   KEY `tx_id` (`tx_id`),

--- a/src/OutputInputIdentification.cpp
+++ b/src/OutputInputIdentification.cpp
@@ -63,7 +63,7 @@ OutputInputIdentification::get_mixin_no()
 void
 OutputInputIdentification::identify_outputs()
 {
-    //          <public_key  , amount  , out idx>
+    //          <public_key  , amount  , out idx, unlock time>
     std::vector<outputs_tuple> outputs = get_outputs_tuple(*tx);
 
     for (auto& out: outputs)
@@ -77,6 +77,7 @@ OutputInputIdentification::identify_outputs()
             = boost::get<cryptonote::txout_to_key>(std::get<0>(out));
         uint64_t amount             = std::get<1>(out);
         uint64_t output_idx_in_tx   = std::get<2>(out);
+        uint64_t unlock_time        = std::get<3>(out);
 
         // get the tx output public key
         // that normally would be generated for us,
@@ -156,7 +157,7 @@ OutputInputIdentification::identify_outputs()
             identified_outputs.emplace_back(
                         output_info{
                                 txout_k.key, derivation.second, amount, output_idx_in_tx,
-                                rtc_outpk, rtc_mask, rtc_amount
+                                rtc_outpk, rtc_mask, rtc_amount, unlock_time
                         });
 
         }

--- a/src/OutputInputIdentification.h
+++ b/src/OutputInputIdentification.h
@@ -56,6 +56,7 @@ public:
     struct output_info
     {
         public_key pub_key;
+        public_key tx_pub_key;
         uint64_t   amount;
         uint64_t   idx_in_tx;
         string     rtc_outpk;
@@ -95,8 +96,9 @@ public:
 
     // public transaction key is combined with our viewkey
     // to create, so called, derived key.
-    std::vector<key_derivation> derivations;
 
+    // stores key derivation and associated tx pub key
+    std::vector<std::pair<key_derivation, public_key> > derivations; 
 
     vector<output_info> identified_outputs;
     vector<input_info>  identified_inputs;
@@ -150,7 +152,7 @@ public:
     get_tx_prefix_hash_str();
 
     virtual string const&
-    get_tx_pub_key_str();
+    get_tx_pub_key_str(size_t index = 0);
 
     virtual uint64_t
     get_mixin_no();

--- a/src/OutputInputIdentification.h
+++ b/src/OutputInputIdentification.h
@@ -62,6 +62,7 @@ public:
         string     rtc_outpk;
         string     rtc_mask;
         string     rtc_amount;
+        uint64_t   unlock_time;
     };
 
     // define a structure to keep information about found

--- a/src/TxSearch.cpp
+++ b/src/TxSearch.cpp
@@ -324,6 +324,7 @@ TxSearch::operator()()
                                 .at(out_data.out_index);
                         out_data.mixin        = tx_data.mixin;
                         out_data.timestamp    = tx_data.timestamp;
+                        out_data.unlock_time  = out_info.unlock_time;
 
                         outputs_found.push_back(std::move(out_data));
 

--- a/src/TxSearch.cpp
+++ b/src/TxSearch.cpp
@@ -255,8 +255,12 @@ TxSearch::operator()()
                                                   .get_tx_hash_str();
                     tx_data.prefix_hash      = oi_identification
                                                   .get_tx_prefix_hash_str();
+
+                    // this will be associated with the outputs from now on, not the tx,
+                    // but for convenience of transition to that, this remains.
                     tx_data.tx_pub_key       = oi_identification
                                                  .get_tx_pub_key_str();
+
                     tx_data.account_id       = acc->id.data;
                     tx_data.blockchain_tx_id = blockchain_tx_id;
                     tx_data.total_received   = oi_identification.total_received;
@@ -310,8 +314,7 @@ TxSearch::operator()()
                         out_data.account_id   = acc->id.data;
                         out_data.tx_id        = tx_mysql_id;
                         out_data.out_pub_key  = pod_to_hex(out_info.pub_key);
-                        out_data.tx_pub_key   = oi_identification
-                                .get_tx_pub_key_str();
+                        out_data.tx_pub_key   = pod_to_hex(out_info.tx_pub_key);
                         out_data.amount       = out_info.amount;
                         out_data.out_index    = out_info.idx_in_tx;
                         out_data.rct_outpk    = out_info.rtc_outpk;

--- a/src/ssqlses.h
+++ b/src/ssqlses.h
@@ -169,7 +169,7 @@ struct XmrTransaction : public Transactions, Table
 
 };
 
-sql_create_13(Outputs, 1, 13,
+sql_create_14(Outputs, 1, 14,
               sql_bigint_unsigned_null, id,               // this is null so that we can set it to mysqlpp:null when inserting rows
               sql_bigint_unsigned, account_id,            // this way auto_increment of the id will take place and we can
               sql_bigint_unsigned, tx_id,                 // use vector of outputs to write at once to mysql
@@ -182,7 +182,8 @@ sql_create_13(Outputs, 1, 13,
               sql_bigint_unsigned, global_index,
               sql_bigint_unsigned, out_index,
               sql_bigint_unsigned, mixin,
-              sql_timestamp      , timestamp);
+              sql_timestamp      , timestamp,
+              sql_bigint_unsigned, unlock_time);
 
 struct XmrOutput : public Outputs, Table
 {
@@ -208,12 +209,12 @@ struct XmrOutput : public Outputs, Table
                                      `tx_pub_key`,
                                      `rct_outpk`, `rct_mask`, `rct_amount`,
                                      `amount`, `global_index`,
-                                     `out_index`, `mixin`, `timestamp`)
+                                     `out_index`, `mixin`, `timestamp`, `unlock_time`)
                             VALUES (%0q, %1q, %2q,
                                     %3q,
                                     %4q, %5q, %6q,
                                     %7q, %8q,
-                                    %9q, %10q, %11q);
+                                    %9q, %10q, %11q, %12q);
     )";
 
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -561,11 +561,19 @@ get_ouputs(const transaction& tx)
 
 vector<outputs_tuple> get_outputs_tuple(const transaction& tx)
 {
-   vector<outputs_tuple> outputs;
+    vector<outputs_tuple> outputs;
 
     for (uint64_t n = 0; n < tx.vout.size(); ++n)
     {
-        outputs.push_back(make_tuple(tx.vout[n].target, tx.vout[n].amount, n));
+        // (Loki) per-output unlock time
+        if (tx.version > 2)
+        {
+            outputs.push_back(make_tuple(tx.vout[n].target, tx.vout[n].amount, n, tx.output_unlock_times[n]));
+        }
+        else
+        {
+            outputs.push_back(make_tuple(tx.vout[n].target, tx.vout[n].amount, n, tx.unlock_time));
+        }
     }
 
     return outputs;

--- a/src/tools.h
+++ b/src/tools.h
@@ -147,7 +147,8 @@ get_mixin_no_in_txs(const vector<transaction>& txs);
 vector<pair<txout_to_key, uint64_t>>
 get_ouputs(const transaction& tx);
 
-typedef tuple<txout_target_v, uint64_t, uint64_t> outputs_tuple;
+//          <public_key  , amount  , out idx, unlock time>
+typedef tuple<txout_target_v, uint64_t, uint64_t, uint64_t> outputs_tuple;
 vector<outputs_tuple> get_outputs_tuple(const transaction& tx);
 
 vector<txin_to_key>


### PR DESCRIPTION
With these changes loki-locker should now support per-output unlock times as well as correctly support (and be able to spend) miner and service node rewards.